### PR TITLE
my-standard-layout-scss を Netlify にデプロイできるようにする

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,37 @@
+# Global settings applied to the whole site.
+#
+# “publish” is the directory to publish (relative to root of your repo),
+# “command” is your build command,
+# “base” is directory to change to before starting build. if you set base:
+#    that is where we will look for package.json/.nvmrc/etc not repo root!
+
+[build]
+  base    = "site"
+  publish = "public"
+  command = "make"
+
+# Production context: All deploys to the main
+# repository branch will inherit these settings.
+[context.production]
+  command = "make production"
+  [context.production.environment]
+    ACCESS_TOKEN = "super secret"
+
+# Deploy Preview context: All Deploy Previews
+# will inherit these settings.
+[context.deploy-preview.environment]
+  ACCESS_TOKEN = "not so secret"
+
+# Branch Deploy context: All deploys that are not in
+# an active Deploy Preview will inherit these settings.
+[context.branch-deploy]
+  command = "make staging"
+
+# Specific branch context: Deploys from this branch
+# will take these settings and override their
+# current ones.
+[context.feature]
+  command = "make feature"
+
+[context."features/branch"]
+  command = "gulp"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,32 +6,6 @@
 #    that is where we will look for package.json/.nvmrc/etc not repo root!
 
 [build]
-  base    = "site"
-  publish = "public"
-  command = "make"
-
-# Production context: All deploys to the main
-# repository branch will inherit these settings.
-[context.production]
-  command = "make production"
-  [context.production.environment]
-    ACCESS_TOKEN = "super secret"
-
-# Deploy Preview context: All Deploy Previews
-# will inherit these settings.
-[context.deploy-preview.environment]
-  ACCESS_TOKEN = "not so secret"
-
-# Branch Deploy context: All deploys that are not in
-# an active Deploy Preview will inherit these settings.
-[context.branch-deploy]
-  command = "make staging"
-
-# Specific branch context: Deploys from this branch
-# will take these settings and override their
-# current ones.
-[context.feature]
-  command = "make feature"
-
-[context."features/branch"]
-  command = "gulp"
+  base    = "my-standard-layout-scss"
+  publish = "src"
+  command = "yarn run build:scss"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,5 +7,5 @@
 
 [build]
   base    = "my-standard-layout-scss"
-  publish = "src"
+  publish = "my-standard-layout-scss/src"
   command = "yarn run build:scss"


### PR DESCRIPTION
my-standard-layout-scss を Netlify にデプロイしたい。

リポジトリの中のサブディレクトリで yarn install && yarn run build:scss するためには設定が必要。

Continuous Deployment | Netlify
https://www.netlify.com/docs/continuous-deployment/#deploy-contexts